### PR TITLE
Relax rails version requirement

### DIFF
--- a/markitup_rails.gemspec
+++ b/markitup_rails.gemspec
@@ -110,7 +110,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rails>, ["~> 3.1"])
+      s.add_runtime_dependency(%q<rails>, [">= 3.1"])
       s.add_runtime_dependency(%q<bluecloth>, [">= 0"])
       s.add_runtime_dependency(%q<bb-ruby>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])


### PR DESCRIPTION
This seems to work fine with Rails 4, at very least for markdown - so I've relaxed the Rails version requirement in the gemspec.
