### PR TITLE
Rails5 compatibility

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   namespace :markitup do
-    match 'parsers/:action', :controller => "parsers", :via => :post
+    match 'parsers/markdown', :controller => "parsers", :via => :post
+    match 'parsers/bbcode', :controller => "parsers", :via => :post
   end     
 end

--- a/markitup_rails.gemspec
+++ b/markitup_rails.gemspec
@@ -118,7 +118,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<rails>, ["~> 3.1"])
+      s.add_dependency(%q<rails>, [">= 3.1"])
       s.add_dependency(%q<bluecloth>, [">= 0"])
       s.add_dependency(%q<bb-ruby>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])


### PR DESCRIPTION
Rails 5 doesn't like wildcard route specs, and they will be deprecated in 5.1 or 5.2. This patch specifically enumerates them, and eliminates deprecation warnings in Rails 5 projects.